### PR TITLE
Fedora 36: Install llvm package so llvm-symbolizer is available.

### DIFF
--- a/fedora-36-amd64.Dockerfile
+++ b/fedora-36-amd64.Dockerfile
@@ -17,7 +17,7 @@ COPY tools /opt/tools
 RUN dnf -y update                                                                                 && \
     dnf -y install sudo wget git openssl-devel bison byacc cmake python perl-Digest-SHA              \
                    json-c-devel clang gcc gcc-c++ make autoconf libtool gzip bzip2 bzip2-devel       \
-                   gettext-devel ncurses-devel zlib-devel asciidoctor botan2 botan2-devel
+                   gettext-devel ncurses-devel zlib-devel asciidoctor botan2 botan2-devel llvm
 
 RUN /opt/tools/tools.sh build_and_install_libiconv                                                  && \
     /opt/tools/tools.sh build_and_install_gpg lts                                                   && \


### PR DESCRIPTION
...so memory leaks could be symbolized right in the GitHub CI, without need to debug things locally.

@maxirmx Is it good idea to install whole llvm, or it could be done with less overhead?